### PR TITLE
Improve databricks seeds

### DIFF
--- a/integration_tests/seeds/_seeds.yml
+++ b/integration_tests/seeds/_seeds.yml
@@ -10,46 +10,46 @@ seeds:
         {% if var('test_data_override') == true -%} {{ true|as_bool }} {%- else -%} {{ false|as_bool }} {%- endif -%}
       column_types:
         patient_id: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         member_id: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         gender: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         race: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         birth_date: date
         death_date: date
         death_flag: integer
         enrollment_start_date: date
         enrollment_end_date: date
         payer: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         payer_type: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         plan: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         original_reason_entitlement_code: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         dual_status_code: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         medicare_status_code: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         first_name: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         last_name: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         address: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         city: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         state: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         zip_code: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         phone: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         data_source: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
 
   - name: medical_claim_seed
     config:
@@ -60,18 +60,18 @@ seeds:
         {% if var('test_data_override') == true -%} {{ true|as_bool }} {%- else -%} {{ false|as_bool }} {%- endif -%}
       column_types:
         claim_id: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         claim_line_number: integer
         claim_type: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         patient_id: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         member_id: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         payer: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         plan: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         claim_start_date: date
         claim_end_date: date
         claim_line_start_date: date
@@ -79,40 +79,40 @@ seeds:
         admission_date: date
         discharge_date: date
         admit_source_code: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         admit_type_code: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         discharge_disposition_code: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         place_of_service_code: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         bill_type_code: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         ms_drg_code: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         apr_drg_code: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         revenue_center_code: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         service_unit_quantity: integer
         hcpcs_code: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         hcpcs_modifier_1: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         hcpcs_modifier_2: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         hcpcs_modifier_3: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         hcpcs_modifier_4: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         hcpcs_modifier_5: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         rendering_npi: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         billing_npi: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         facility_npi: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         paid_date: date
         paid_amount: float
         allowed_amount: float
@@ -122,159 +122,159 @@ seeds:
         deductible_amount: float
         total_cost_amount: float
         diagnosis_code_type: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         diagnosis_code_1: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         diagnosis_code_2: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         diagnosis_code_3: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         diagnosis_code_4: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         diagnosis_code_5: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         diagnosis_code_6: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         diagnosis_code_7: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         diagnosis_code_8: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         diagnosis_code_9: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         diagnosis_code_10: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         diagnosis_code_11: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         diagnosis_code_12: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         diagnosis_code_13: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         diagnosis_code_14: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         diagnosis_code_15: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         diagnosis_code_16: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         diagnosis_code_17: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         diagnosis_code_18: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         diagnosis_code_19: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         diagnosis_code_20: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         diagnosis_code_21: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         diagnosis_code_22: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         diagnosis_code_23: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         diagnosis_code_24: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         diagnosis_code_25: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         diagnosis_poa_1: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         diagnosis_poa_2: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         diagnosis_poa_3: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         diagnosis_poa_4: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         diagnosis_poa_5: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         diagnosis_poa_6: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         diagnosis_poa_7: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         diagnosis_poa_8: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         diagnosis_poa_9: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         diagnosis_poa_10: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         diagnosis_poa_11: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         diagnosis_poa_12: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         diagnosis_poa_13: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         diagnosis_poa_14: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         diagnosis_poa_15: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         diagnosis_poa_16: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         diagnosis_poa_17: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         diagnosis_poa_18: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         diagnosis_poa_19: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         diagnosis_poa_20: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         diagnosis_poa_21: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         diagnosis_poa_22: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         diagnosis_poa_23: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         diagnosis_poa_24: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         diagnosis_poa_25: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         procedure_code_type: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         procedure_code_1: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         procedure_code_2: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         procedure_code_3: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         procedure_code_4: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         procedure_code_5: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         procedure_code_6: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         procedure_code_7: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         procedure_code_8: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         procedure_code_9: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         procedure_code_10: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         procedure_code_11: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         procedure_code_12: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         procedure_code_13: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         procedure_code_14: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         procedure_code_15: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         procedure_code_16: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         procedure_code_17: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         procedure_code_18: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         procedure_code_19: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         procedure_code_20: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         procedure_code_21: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         procedure_code_22: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         procedure_code_23: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         procedure_code_24: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         procedure_code_25: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         procedure_date_1: date
         procedure_date_2: date
         procedure_date_3: date
@@ -301,7 +301,7 @@ seeds:
         procedure_date_24: date
         procedure_date_25: date
         data_source: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
 
   - name: pharmacy_claim_seed
     config:
@@ -312,23 +312,23 @@ seeds:
         {% if var('test_data_override') == true -%} {{ true|as_bool }} {%- else -%} {{ false|as_bool }} {%- endif -%}
       column_types:
         claim_id: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         claim_line_number: integer
         patient_id: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         member_id: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         payer: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         plan: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         prescribing_provider_npi: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         dispensing_provider_npi: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         dispensing_date: date
         ndc_code: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}
         quantity: integer
         days_supply: integer
         refills: integer
@@ -336,4 +336,4 @@ seeds:
         paid_amount: float
         allowed_amount: float
         data_source: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(255) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(255) {%- endif -%}

--- a/macros/load_seed.sql
+++ b/macros/load_seed.sql
@@ -119,11 +119,7 @@ from files (format = 'csv',
 {%- set collist = [] -%}
 
 {% for col in columns %}
-  {% if headers == true %}
-    {% do collist.append(col.name ~ "::" ~ col.dtype ~ " AS " ~ col.name ) %}
-  {% else %}
-    {% do collist.append("_c" ~ loop.index0 ~ "::" ~ col.dtype ~ " AS " ~ col.name ) %}
-  {% endif %}
+  {% do collist.append("_c" ~ loop.index0 ~ "::" ~ col.dtype ~ " AS " ~ col.name ) %}
 {% endfor %}
 
 {%- set cols = collist|join(',\n    ') -%}
@@ -148,7 +144,7 @@ FROM (
 FILEFORMAT = CSV
 PATTERN = '{{ pattern }}*'
 FORMAT_OPTIONS (
-  {% if headers == true %} 'header' = 'true', {% else %} 'header' = 'false', {% endif %}
+  {% if headers == true %} 'skipRows' = '1', {% else %} 'skipRows' = '0', {% endif %}
   {% if null_marker == true %} 'nullValue' = '\\N', {% else %} {% endif %}
   'enforceSchema' = 'true',
   'inferSchema' = 'false',

--- a/seeds/terminology/terminology_seeds.yml
+++ b/seeds/terminology/terminology_seeds.yml
@@ -189,7 +189,7 @@ seeds:
         recid : |
           {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar {%- endif -%}
         long_description : |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(2000) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(2000) {%- endif -%}
         short_description : |
           {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar {%- endif -%}
 
@@ -488,13 +488,13 @@ seeds:
       alias: other_provider_taxonomy
       column_types:
         npi: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(35) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(35) {%- endif -%}
         taxonomy_code: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(35) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(35) {%- endif -%}
         medicare_specialty_code: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(173) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(173) {%- endif -%}
         description: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(101) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(101) {%- endif -%}
         primary_flag:  integer
 
         
@@ -548,37 +548,37 @@ seeds:
       alias: provider
       column_types:
         npi: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(35) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(35) {%- endif -%}
         entity_type_code: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(26) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(26) {%- endif -%}
         entity_type_description: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(37) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(37) {%- endif -%}
         primary_taxonomy_code: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(35) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(35) {%- endif -%}
         primary_specialty_description: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(173) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(173) {%- endif -%}
         provider_first_name: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(95) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(95) {%- endif -%}
         provider_last_name: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(95) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(95) {%- endif -%}
         provider_organization_name: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(95) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(95) {%- endif -%}
         parent_organization_name: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(95) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(95) {%- endif -%}
         practice_address_line_1: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(80) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(80) {%- endif -%}
         practice_address_line_2: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(80) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(80) {%- endif -%}
         practice_city: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(65) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(65) {%- endif -%}
         practice_state: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(65) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(65) {%- endif -%}
         practice_zip_code: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(42) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(42) {%- endif -%}
         last_updated: date
         deactivation_date: date
         deactivation_flag: |
-          {%- if target.type == "bigquery" -%} string {%- else -%} varchar(80) {%- endif -%}
+          {%- if target.type in ("bigquery", "databricks") -%} string {%- else -%} varchar(80) {%- endif -%}
 
   - name: terminology__race
     config:


### PR DESCRIPTION
## Describe your changes

The macro `databricks__load_seed` now uses the `skipRows` option instead of the `header` option to optionally include or skip the first row of the CSV seed files in S3.  The `header=true` option requires exact matching between the S3 column names and the names defined in the template (local) `.csv` seed file.

By using `skipRows`, small differences (ex. misspelled columns, etc.) are ignored and the column names/types are taken only from the `.yml` definitions.

Additionally, all instances of `if target.type == "bigquery"` are replaced with `if target.type in ("bigquery", "databricks")` since Databricks and Bigquery both use the `string` type.


## How has this been tested?
Successful run of `dbt seed` and full integration tests `dbt build`.  Verified that column header rows were being skipped where `headers=true` in seed post-hooks.

```
18:36:19  Finished running 48 view models, 71 seeds, 164 table models, 42 tests in 0 hours 6 minutes and 23.11 seconds (383.11s).
18:36:20  
18:36:20  Completed successfully
18:36:20  
18:36:20  Done. PASS=325 WARN=0 ERROR=0 SKIP=0 TOTAL=325
```

## Reviewer focus

The post-hooks themselves were not affected, and no other adapters should be affected.


## Checklist before requesting a review
- [ ] I have updated the version number in dbt_project.yml file to reflect the release number of this PR
- [ ] I have updated the docs files (by running dbt docs generate/serve and copying the necessary files into the docs folder)
- [ ] I have commented my code as necessary
- [ ] I have added at least one Github label to this PR
- [ ] My code follows style guidelines
- [ ] (Optional) I have recorded a Loom to explain this PR


## (Optional) Gif of how this PR makes you feel

![](https://media.tenor.com/wCZAG1SxnAgAAAAC/lil-yachty-drake.gif)

## Loom link
